### PR TITLE
Add export-ignore to .editorconfig in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 /benchmark/ export-ignore
 /docs/ export-ignore
 /test/ export-ignore
-/.editorconfig
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.laminas-ci.json export-ignore
@@ -20,3 +20,4 @@
 /vendor-bin/ export-ignore
 
 /phpstan.neon export-ignore
+


### PR DESCRIPTION
Current archive targets are as follows,
```
composer.json
.editorconfig
LICENSE
rules.neon
```

With this PR, the archive targets will be as follows:
```
composer.json
LICENSE
rules.neon
```